### PR TITLE
ac/1.8.7.1-updates-github-readme-files

### DIFF
--- a/Driverless AI/ES/README.md
+++ b/Driverless AI/ES/README.md
@@ -2,6 +2,6 @@
 
 # Driverless AI
 
-Este repositorio contiene tutoriales que se centran en Driverless AI versión 1.8.4.1.
+Este repositorio contiene tutoriales que se centran en Driverless AI versión 1.8.7.1.
 
 Próximamente..

--- a/Driverless AI/PT/README.md
+++ b/Driverless AI/PT/README.md
@@ -2,6 +2,6 @@
 
 # Driverless AI
 
-Este repositório tem tutoriais voltados para a versão 1.8.4.1
+Este repositório tem tutoriais voltados para a versão 1.8.7.1
 
 Em breve.

--- a/Driverless AI/README.md
+++ b/Driverless AI/README.md
@@ -4,7 +4,7 @@
 
 # Driverless AI
 
-This repository has tutorials that focus on **Driverless AI version 1.8.4.1**.
+This repository has tutorials that focus on **Driverless AI version 1.8.7.1**.
 
 Check out the [**New H2O.ai Learning Center**](https://training.h2o.ai/) where you can earn **badges** for completing the Self-Paced Tutorials or Instructor-Led Courses. 
 
@@ -26,8 +26,11 @@ Check out the [**New H2O.ai Learning Center**](https://training.h2o.ai/) where y
 
 - [Build Your Own Recipe Tutorial](https://training.h2o.ai/products/tutorial-3b-build-your-own-custom-recipe-tutorial)
 
+- [NEW - Scoring Pipeline Deployment Introduction](https://training.h2o.ai/products/tutorial-4a-scoring-pipeline-deployment-introduction)
 
 For other versions of the **Driverless AI tutorials**, check out the following repo's:
+
+- [Driverless AI Tutorials 1.8.4.1 Repo](https://github.com/h2oai/tutorials/tree/1.8.4.1/DriverlessAI)
 
 - [Driverless AI Tutorials 1.8.0 Repo](https://github.com/h2oai/tutorials/tree/1.8.0/DriverlessAI)
 

--- a/H2O/README.md
+++ b/H2O/README.md
@@ -4,11 +4,14 @@ This repository has tutorials that focus on H2O-3 Open Source Machine Learning P
 
 Check out our [**New Tutorials Portal**](https://h2oai.github.io/tutorials/) where you will find our **latest Driverless AI and H2O-3 tutorials** including: 
 
-- [Introduction to Machine Learning with H2O - Part 1](https://h2oai.github.io/tutorials/introduction-to-machine-learning-with-h2o-part-1/#0)
+- [Introduction to Machine Learning with H2O - Part 1](https://training.h2o.ai/products/introduction-to-machine-learning-with-h2o-3-part-1)
+- [Introduction to Machine Learning with H2O - Part 2](https://training.h2o.ai/products/introduction-to-machine-learning-with-h2o-3-part-2)
+- [Introduction to Machine Learning with H2O - Part 3](https://training.h2o.ai/products/introduction-to-machine-learning-with-h2o-3-part-3)
+
 
 ## Running Into Issues With Tutorials?
 
-If you run into problems that prevent you from completing a tutorial, head on over to [H2O's Slack Channel](https://www.h2o.ai/community/driverless-ai-community/) and chat with Data Scientists all over the world.
+If you run into problems that prevent you from completing a tutorial, head on over to the [H2O.ai Community (Hac)](https://www.h2o.ai/community/home) and chat with Data Scientists all over the world.
 
 If you are certain there is an issue with the tutorial, please [create a new issue on Github](https://github.com/h2oai/tutorials/issues), and we will do our best to resolve resolve it.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tutorials are developed and maintained on Github and published onto the [H2O.ai 
 
 ## New to AI?
 
-Begin your journey by browsing the tutorials directory of this GitHub repository.
+Begin your journey by browsing the tutorials in the [H2O.ai Learning Center](https://training.h2o.ai/) under Self-Paced Tutorials..
 
 ## Running Into Issues With Tutorials?
 


### PR DESCRIPTION
Updated the following files to reference DAI 1.8.7.1:

- tutorials/README.md
- tutorials/Driverless AI/PT/README.md
- tutorials/Driverless AI/ES/README.md
- tutorials/Driverless AI/README.md
- Add links to the new H2O-3 tutorials under tutorials/H2O/README.md